### PR TITLE
Upgrade pnpm to v9.15.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on: [push]
 
 env:
   NODE_VERSION: 20
-  PNPM_VERSION: 9.15.3
 jobs:
   app:
     runs-on: ubuntu-latest
@@ -11,7 +10,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "app/package.json"
       - uses: actions/setup-node@v4
         with:
@@ -70,7 +68,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "admin/package.json"
       - uses: actions/setup-node@v4
         with:

--- a/admin/package.json
+++ b/admin/package.json
@@ -2,7 +2,7 @@
   "name": "admin",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9.15.3",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "next dev -p 3002",
     "build": "next build",

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@9.15.3",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "next dev --turbopack -p 3001",
     "build": "next build",


### PR DESCRIPTION
CIでPNPM_VERSIONを指定する必要はない：https://github.com/pnpm/action-setup/tree/v4/

> Optional when there is a [packageManager field in the package.json](https://nodejs.org/api/corepack.html).